### PR TITLE
Add support for routes and alias in network configuration

### DIFF
--- a/apiv1/agent_env.go
+++ b/apiv1/agent_env.go
@@ -54,6 +54,8 @@ type NetworkSpec struct {
 
 	DNS     []string `json:"dns"`
 	Default []string `json:"default"`
+	Routes  []Route  `json:"routes"`
+	Alias   string   `json:"alias,omitempty"`
 
 	MAC string `json:"mac"`
 

--- a/apiv1/agent_env_factory.go
+++ b/apiv1/agent_env_factory.go
@@ -40,8 +40,9 @@ func (f AgentEnvFactory) ForVM(
 
 			DNS:     typedNet.spec.DNS,
 			Default: typedNet.spec.Default,
-
-			MAC: typedNet.mac,
+			Routes:  typedNet.spec.Routes,
+			Alias:   typedNet.spec.Alias,
+			MAC:     typedNet.mac,
 
 			Preconfigured: typedNet.preconfigured,
 		}

--- a/apiv1/networks.go
+++ b/apiv1/networks.go
@@ -25,6 +25,8 @@ type Network interface {
 	SetMAC(string)
 	SetDNS([]string)
 	SetPreconfigured()
+	SetAlias(a string)
+	AddRoute(string, string, string)
 
 	CloudProps() NetworkCloudProps
 
@@ -38,6 +40,12 @@ type Network interface {
 
 type NetworkCloudProps interface {
 	As(interface{}) error
+}
+
+type Route struct {
+	Destination string
+	Gateway     string
+	Netmask     string
 }
 
 type NetworkImpl struct {
@@ -56,9 +64,10 @@ type networkSpec2 struct {
 	Netmask string `json:"netmask,omitempty"`
 	Gateway string `json:"gateway,omitempty"`
 
-	DNS     []string `json:"dns"`
-	Default []string `json:"default"`
-
+	DNS        []string       `json:"dns"`
+	Default    []string       `json:"default"`
+	Routes     []Route        `json:"routes"`
+	Alias      string         `json:"alias,omitempty"`
 	CloudProps CloudPropsImpl `json:"cloud_properties"`
 }
 
@@ -71,6 +80,8 @@ type NetworkOpts struct {
 
 	DNS     []string
 	Default []string
+	Routes  []Route  `json:"routes"`
+	Alias   string   `json:"alias,omitempty"`
 
 	CloudProps CloudPropsImpl `json:"cloud_properties"`
 }
@@ -86,6 +97,8 @@ func NewNetwork(opts NetworkOpts) Network {
 
 			DNS:     opts.DNS,
 			Default: opts.Default,
+			Routes:  opts.Routes,
+			Alias:   opts.Alias,
 		},
 	}
 }
@@ -102,6 +115,14 @@ func (n NetworkImpl) Default() []string { return n.spec.Default }
 func (n *NetworkImpl) SetMAC(mac string)           { n.mac = mac }
 func (n *NetworkImpl) SetDNS(nameservers []string) { n.spec.DNS = nameservers }
 func (n *NetworkImpl) SetPreconfigured()           { n.preconfigured = true }
+func (n *NetworkImpl) SetAlias(a string)           { n.spec.Alias = a }
+func (n *NetworkImpl) AddRoute(ip, netmask, gw string) {
+	n.spec.Routes = append(n.spec.Routes, Route{
+		Destination: ip,
+		Gateway:     gw,
+		Netmask:     netmask,
+	})
+}
 
 func (n NetworkImpl) CloudProps() NetworkCloudProps { return n.spec.CloudProps }
 

--- a/apiv1/networks_test.go
+++ b/apiv1/networks_test.go
@@ -29,6 +29,7 @@ var _ = Describe("Networks", func() {
 
 	        "dns":     ["fake-dns"],
 	        "default": ["fake-default"],
+	        "routes":  [],
 
 	        "cloud_properties": {"fake-cp-key": "fake-cp-value"}
 	      },
@@ -37,6 +38,7 @@ var _ = Describe("Networks", func() {
 
 	        "dns":     ["fake-dns2"],
 	        "default": ["fake-default2"],
+	        "routes":  [],
 
 	        "cloud_properties": {"fake-cp-key2": "fake-cp-value2"}
 	      }


### PR DESCRIPTION
This PR adds support for agent's [route](https://github.com/cloudfoundry/bosh-agent/blob/main/settings/settings.go#L363) and [alias](https://github.com/cloudfoundry/bosh-agent/blob/main/settings/settings.go#L365) configuration of networks.

These features are useful for go written CPIs that need fine tuning of the network configuration, especially in Multi-homed VMs environment. 