### PR TITLE
remove blobstore info from iaas metada endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ CPIs using this library:
 - [Docker CPI](https://github.com/cppforlife/bosh-docker-cpi-release)
 - [Kubernetes CPI](https://github.com/bosh-cpis/bosh-kubernetes-cpi-release)
 
+## Test
+run ginkgo v1
+`go run github.com/onsi/ginkgo/ginkgo@v1.16.1 -r .`
 ## Todos
 
 - rename apiv1 to api package

--- a/apiv1/agent_env.go
+++ b/apiv1/agent_env.go
@@ -29,8 +29,6 @@ type agentEnvSpec struct {
 	Mbus string   `json:"mbus"`
 	NTP  []string `json:"ntp"`
 
-	Blobstore BlobstoreSpec `json:"blobstore"`
-
 	Networks NetworksSpec `json:"networks"`
 
 	Disks DisksSpec `json:"disks"`
@@ -71,11 +69,6 @@ type DisksSpec struct {
 type PersistentSpec map[string]DiskHint
 
 type EnvSpec map[string]interface{}
-
-type BlobstoreSpec struct {
-	Provider string                 `json:"provider"`
-	Options  map[string]interface{} `json:"options"`
-}
 
 func (ae *AgentEnvImpl) AttachSystemDisk(hint DiskHint) {
 	ae.spec.Disks.System = hint

--- a/apiv1/agent_env_factory.go
+++ b/apiv1/agent_env_factory.go
@@ -59,11 +59,6 @@ func (f AgentEnvFactory) ForVM(
 		Mbus: agentOptions.Mbus,
 		NTP:  agentOptions.NTP,
 
-		Blobstore: BlobstoreSpec{
-			Provider: agentOptions.Blobstore.Type,
-			Options:  agentOptions.Blobstore.Options,
-		},
-
 		Networks: networksSpec,
 
 		Env: EnvSpec(env.val), // todo deep copy env?

--- a/apiv1/agent_env_factory_test.go
+++ b/apiv1/agent_env_factory_test.go
@@ -31,13 +31,6 @@ var _ = Describe("AgentEnvFactory", func() {
 			agentOptions := AgentOptions{
 				Mbus: "fake-mbus",
 				NTP:  []string{"fake-ntp"},
-
-				Blobstore: BlobstoreOptions{
-					Type: "fake-blobstore-type",
-					Options: map[string]interface{}{
-						"fake-blobstore-key": "fake-blobstore-value",
-					},
-				},
 			}
 
 			agentEnv1 := AgentEnvFactory{}.ForVM(
@@ -58,13 +51,6 @@ var _ = Describe("AgentEnvFactory", func() {
 
         "mbus": "fake-mbus",
         "ntp": ["fake-ntp"],
-
-        "blobstore": {
-          "provider": "fake-blobstore-type",
-          "options": {
-            "fake-blobstore-key": "fake-blobstore-value"
-          }
-        },
 
         "networks": {
           "fake-net-name": {

--- a/apiv1/agent_env_test.go
+++ b/apiv1/agent_env_test.go
@@ -162,13 +162,6 @@ var _ = Describe("AgentEnv", func() {
 			agentOptions := AgentOptions{
 				Mbus: "fake-mbus",
 				NTP:  []string{"fake-ntp"},
-
-				Blobstore: BlobstoreOptions{
-					Type: "fake-blobstore-type",
-					Options: map[string]interface{}{
-						"fake-blobstore-key": "fake-blobstore-value",
-					},
-				},
 			}
 
 			agentEnvJSON := `{
@@ -181,13 +174,6 @@ var _ = Describe("AgentEnv", func() {
 
         "mbus": "fake-mbus",
         "ntp": ["fake-ntp"],
-
-        "blobstore": {
-          "provider": "fake-blobstore-type",
-          "options": {
-            "fake-blobstore-key": "fake-blobstore-value"
-          }
-        },
 
         "networks": {
           "fake-net-name": {

--- a/apiv1/agent_options.go
+++ b/apiv1/agent_options.go
@@ -5,32 +5,13 @@ import (
 )
 
 type AgentOptions struct {
-	Mbus      string   // e.g. "https://user:password@127.0.0.1:4321/agent"
-	NTP       []string // e.g. ["0.us.pool.ntp.org"]. Ok to be empty
-	Blobstore BlobstoreOptions
-}
-
-type BlobstoreOptions struct {
-	Type    string `json:"provider"`
-	Options map[string]interface{}
+	Mbus string   // e.g. "https://user:password@127.0.0.1:4321/agent"
+	NTP  []string // e.g. ["0.us.pool.ntp.org"]. Ok to be empty
 }
 
 func (o AgentOptions) Validate() error {
 	if o.Mbus == "" {
 		return bosherr.Error("Must provide non-empty Mbus")
-	}
-
-	err := o.Blobstore.Validate()
-	if err != nil {
-		return bosherr.WrapError(err, "Validating Blobstore configuration")
-	}
-
-	return nil
-}
-
-func (o BlobstoreOptions) Validate() error {
-	if o.Type == "" {
-		return bosherr.Error("Must provide non-empty Type")
 	}
 
 	return nil

--- a/apiv1/agent_options_test.go
+++ b/apiv1/agent_options_test.go
@@ -17,10 +17,6 @@ var _ = Describe("AgentOptions", func() {
 			opts = AgentOptions{
 				Mbus: "fake-mbus",
 				NTP:  []string{},
-
-				Blobstore: BlobstoreOptions{
-					Type: "fake-blobstore-type",
-				},
 			}
 		})
 
@@ -35,42 +31,6 @@ var _ = Describe("AgentOptions", func() {
 			err := opts.Validate()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("Must provide non-empty Mbus"))
-		})
-
-		It("returns error if blobstore section is not valid", func() {
-			opts.Blobstore.Type = ""
-
-			err := opts.Validate()
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("Validating Blobstore configuration"))
-		})
-	})
-})
-
-var _ = Describe("BlobstoreOptions", func() {
-	var (
-		opts BlobstoreOptions
-	)
-
-	Describe("Validate", func() {
-		BeforeEach(func() {
-			opts = BlobstoreOptions{
-				Type:    "fake-type",
-				Options: map[string]interface{}{"fake-key": "fake-value"},
-			}
-		})
-
-		It("does not return error if all fields are valid", func() {
-			err := opts.Validate()
-			Expect(err).ToNot(HaveOccurred())
-		})
-
-		It("returns error if Type is empty", func() {
-			opts.Type = ""
-
-			err := opts.Validate()
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("Must provide non-empty Type"))
 		})
 	})
 })


### PR DESCRIPTION
The BOSH agent reads its blobstore settings from the metadata API endpoint (or equivalent) for its VM within the IaaS. If the blobstore settings are not set in the `env.bosh.blobstores` property, it will fallback to the top-level `blobstore` property in the metadata.

However, in modern configurations, the Director always sends the blobstore settings as part of the environment hash. Additionally, the Director does redaction of credentials in the environment hash when the signed URLs blobstore feature is enabled. This redaction is not applied to the top-level `blobstore` property in the metadata because that is generated solely by the CPI.

Rather than updating each CPI to know about the signed URL feature, we are instead removing the `blobstore` properties from the CPI. This will ensure that Director is the sole point of contact when configuring agent blobstore settings, and ensure that they are always properly redacted.

related to https://github.com/cloudfoundry/bosh-google-cpi-release/commit/18b0e08cfdda5832d28cf568d93a4e37ce0c5a1f
and will solve issue https://github.com/cloudfoundry/bosh-deployment/issues/450