### PR TITLE
Add opt-in update_disk support via DiskUpdater interface

### DIFF
--- a/apiv1/action_factory.go
+++ b/apiv1/action_factory.go
@@ -132,6 +132,9 @@ func (f ActionFactory) Create(method string, apiVersion int, context CallContext
 		}, nil
 
 	case "update_disk":
+		if apiVersion < 2 {
+			return nil, bosherr.Errorf("Method 'update_disk' requires CPI API version 2 or higher")
+		}
 		return func(diskCID DiskCID, size int, props CloudPropsImpl) (interface{}, error) {
 			return cpi.UpdateDisk(diskCID, size, props)
 		}, nil

--- a/apiv1/action_factory.go
+++ b/apiv1/action_factory.go
@@ -131,6 +131,11 @@ func (f ActionFactory) Create(method string, apiVersion int, context CallContext
 			return nil, cpi.ResizeDisk(diskCID, size)
 		}, nil
 
+	case "update_disk":
+		return func(diskCID DiskCID, size int, props CloudPropsImpl) (interface{}, error) {
+			return cpi.UpdateDisk(diskCID, size, props)
+		}, nil
+
 	case "set_disk_metadata":
 		return func(diskCID DiskCID, metadata DiskMeta) (interface{}, error) {
 			return nil, cpi.SetDiskMetadata(diskCID, metadata)

--- a/apiv1/action_factory.go
+++ b/apiv1/action_factory.go
@@ -135,8 +135,12 @@ func (f ActionFactory) Create(method string, apiVersion int, context CallContext
 		if apiVersion < 2 {
 			return nil, bosherr.Errorf("Method 'update_disk' requires CPI API version 2 or higher")
 		}
+		updater, ok := cpi.(DiskUpdater)
+		if !ok {
+			return nil, bosherr.Errorf("Method 'update_disk' is not supported by this CPI")
+		}
 		return func(diskCID DiskCID, size int, props CloudPropsImpl) (interface{}, error) {
-			return cpi.UpdateDisk(diskCID, size, props)
+			return updater.UpdateDisk(diskCID, size, props)
 		}, nil
 
 	case "set_disk_metadata":

--- a/apiv1/action_factory.go
+++ b/apiv1/action_factory.go
@@ -139,7 +139,7 @@ func (f ActionFactory) Create(method string, apiVersion int, context CallContext
 		if !ok {
 			return nil, bosherr.Errorf("Method 'update_disk' is not supported by this CPI")
 		}
-		return func(diskCID DiskCID, size int, props CloudPropsImpl) (interface{}, error) {
+		return func(diskCID DiskCID, size int, props CloudPropsImpl) (*DiskCID, error) {
 			return updater.UpdateDisk(diskCID, size, props)
 		}, nil
 

--- a/apiv1/action_factory.go
+++ b/apiv1/action_factory.go
@@ -137,7 +137,9 @@ func (f ActionFactory) Create(method string, apiVersion int, context CallContext
 		}
 		updater, ok := cpi.(DiskUpdater)
 		if !ok {
-			return nil, bosherr.Errorf("Method 'update_disk' is not supported by this CPI")
+			return func(diskCID DiskCID, size int, props CloudPropsImpl) (DiskCID, error) {
+				return DiskCID{}, notSupportedError{"Method 'update_disk' is not supported by this CPI"}
+			}, nil
 		}
 		return func(diskCID DiskCID, size int, props CloudPropsImpl) (DiskCID, error) {
 			return updater.UpdateDisk(diskCID, size, props)
@@ -160,3 +162,11 @@ func (f ActionFactory) Create(method string, apiVersion int, context CallContext
 		return nil, bosherr.Errorf("Unknown method '%s'", method)
 	}
 }
+
+// notSupportedError is returned by the update_disk action when the CPI does not
+// implement DiskUpdater. Its Type() method causes rpc.JSONDispatcher to emit
+// Bosh::Clouds::NotSupported so the director can fall back cleanly.
+type notSupportedError struct{ msg string }
+
+func (e notSupportedError) Error() string { return e.msg }
+func (e notSupportedError) Type() string  { return "Bosh::Clouds::NotSupported" }

--- a/apiv1/action_factory.go
+++ b/apiv1/action_factory.go
@@ -139,7 +139,7 @@ func (f ActionFactory) Create(method string, apiVersion int, context CallContext
 		if !ok {
 			return nil, bosherr.Errorf("Method 'update_disk' is not supported by this CPI")
 		}
-		return func(diskCID DiskCID, size int, props CloudPropsImpl) (*DiskCID, error) {
+		return func(diskCID DiskCID, size int, props CloudPropsImpl) (DiskCID, error) {
 			return updater.UpdateDisk(diskCID, size, props)
 		}, nil
 

--- a/apiv1/apiv1fakes/fake_cpi.go
+++ b/apiv1/apiv1fakes/fake_cpi.go
@@ -163,6 +163,17 @@ type FakeCPI struct {
 	resizeDiskReturns struct {
 		result1 error
 	}
+	UpdateDiskStub        func(apiv1.DiskCID, int, apiv1.DiskCloudProps) (interface{}, error)
+	updateDiskMutex       sync.RWMutex
+	updateDiskArgsForCall []struct {
+		arg1 apiv1.DiskCID
+		arg2 int
+		arg3 apiv1.DiskCloudProps
+	}
+	updateDiskReturns struct {
+		result1 interface{}
+		result2 error
+	}
 	SnapshotDiskStub        func(apiv1.DiskCID, apiv1.DiskMeta) (apiv1.SnapshotCID, error)
 	snapshotDiskMutex       sync.RWMutex
 	snapshotDiskArgsForCall []struct {
@@ -772,6 +783,41 @@ func (fake *FakeCPI) ResizeDiskReturns(result1 error) {
 	}{result1}
 }
 
+func (fake *FakeCPI) UpdateDisk(arg1 apiv1.DiskCID, arg2 int, arg3 apiv1.DiskCloudProps) (interface{}, error) {
+	fake.updateDiskMutex.Lock()
+	fake.updateDiskArgsForCall = append(fake.updateDiskArgsForCall, struct {
+		arg1 apiv1.DiskCID
+		arg2 int
+		arg3 apiv1.DiskCloudProps
+	}{arg1, arg2, arg3})
+	fake.recordInvocation("UpdateDisk", []interface{}{arg1, arg2, arg3})
+	fake.updateDiskMutex.Unlock()
+	if fake.UpdateDiskStub != nil {
+		return fake.UpdateDiskStub(arg1, arg2, arg3)
+	}
+	return fake.updateDiskReturns.result1, fake.updateDiskReturns.result2
+}
+
+func (fake *FakeCPI) UpdateDiskCallCount() int {
+	fake.updateDiskMutex.RLock()
+	defer fake.updateDiskMutex.RUnlock()
+	return len(fake.updateDiskArgsForCall)
+}
+
+func (fake *FakeCPI) UpdateDiskArgsForCall(i int) (apiv1.DiskCID, int, apiv1.DiskCloudProps) {
+	fake.updateDiskMutex.RLock()
+	defer fake.updateDiskMutex.RUnlock()
+	return fake.updateDiskArgsForCall[i].arg1, fake.updateDiskArgsForCall[i].arg2, fake.updateDiskArgsForCall[i].arg3
+}
+
+func (fake *FakeCPI) UpdateDiskReturns(result1 interface{}, result2 error) {
+	fake.UpdateDiskStub = nil
+	fake.updateDiskReturns = struct {
+		result1 interface{}
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakeCPI) SnapshotDisk(arg1 apiv1.DiskCID, arg2 apiv1.DiskMeta) (apiv1.SnapshotCID, error) {
 	fake.snapshotDiskMutex.Lock()
 	fake.snapshotDiskArgsForCall = append(fake.snapshotDiskArgsForCall, struct {
@@ -953,6 +999,8 @@ func (fake *FakeCPI) Invocations() map[string][][]interface{} {
 	defer fake.hasDiskMutex.RUnlock()
 	fake.resizeDiskMutex.RLock()
 	defer fake.resizeDiskMutex.RUnlock()
+	fake.updateDiskMutex.RLock()
+	defer fake.updateDiskMutex.RUnlock()
 	fake.snapshotDiskMutex.RLock()
 	defer fake.snapshotDiskMutex.RUnlock()
 	fake.deleteSnapshotMutex.RLock()

--- a/apiv1/apiv1fakes/fake_cpi.go
+++ b/apiv1/apiv1fakes/fake_cpi.go
@@ -163,7 +163,7 @@ type FakeCPI struct {
 	resizeDiskReturns struct {
 		result1 error
 	}
-	UpdateDiskStub        func(apiv1.DiskCID, int, apiv1.DiskCloudProps) (interface{}, error)
+	UpdateDiskStub        func(apiv1.DiskCID, int, apiv1.DiskCloudProps) (*apiv1.DiskCID, error)
 	updateDiskMutex       sync.RWMutex
 	updateDiskArgsForCall []struct {
 		arg1 apiv1.DiskCID
@@ -171,7 +171,7 @@ type FakeCPI struct {
 		arg3 apiv1.DiskCloudProps
 	}
 	updateDiskReturns struct {
-		result1 interface{}
+		result1 *apiv1.DiskCID
 		result2 error
 	}
 	SnapshotDiskStub        func(apiv1.DiskCID, apiv1.DiskMeta) (apiv1.SnapshotCID, error)
@@ -783,7 +783,7 @@ func (fake *FakeCPI) ResizeDiskReturns(result1 error) {
 	}{result1}
 }
 
-func (fake *FakeCPI) UpdateDisk(arg1 apiv1.DiskCID, arg2 int, arg3 apiv1.DiskCloudProps) (interface{}, error) {
+func (fake *FakeCPI) UpdateDisk(arg1 apiv1.DiskCID, arg2 int, arg3 apiv1.DiskCloudProps) (*apiv1.DiskCID, error) {
 	fake.updateDiskMutex.Lock()
 	fake.updateDiskArgsForCall = append(fake.updateDiskArgsForCall, struct {
 		arg1 apiv1.DiskCID
@@ -810,10 +810,10 @@ func (fake *FakeCPI) UpdateDiskArgsForCall(i int) (apiv1.DiskCID, int, apiv1.Dis
 	return fake.updateDiskArgsForCall[i].arg1, fake.updateDiskArgsForCall[i].arg2, fake.updateDiskArgsForCall[i].arg3
 }
 
-func (fake *FakeCPI) UpdateDiskReturns(result1 interface{}, result2 error) {
+func (fake *FakeCPI) UpdateDiskReturns(result1 *apiv1.DiskCID, result2 error) {
 	fake.UpdateDiskStub = nil
 	fake.updateDiskReturns = struct {
-		result1 interface{}
+		result1 *apiv1.DiskCID
 		result2 error
 	}{result1, result2}
 }

--- a/apiv1/apiv1fakes/fake_cpi.go
+++ b/apiv1/apiv1fakes/fake_cpi.go
@@ -163,7 +163,7 @@ type FakeCPI struct {
 	resizeDiskReturns struct {
 		result1 error
 	}
-	UpdateDiskStub        func(apiv1.DiskCID, int, apiv1.DiskCloudProps) (*apiv1.DiskCID, error)
+	UpdateDiskStub        func(apiv1.DiskCID, int, apiv1.DiskCloudProps) (apiv1.DiskCID, error)
 	updateDiskMutex       sync.RWMutex
 	updateDiskArgsForCall []struct {
 		arg1 apiv1.DiskCID
@@ -171,7 +171,7 @@ type FakeCPI struct {
 		arg3 apiv1.DiskCloudProps
 	}
 	updateDiskReturns struct {
-		result1 *apiv1.DiskCID
+		result1 apiv1.DiskCID
 		result2 error
 	}
 	SnapshotDiskStub        func(apiv1.DiskCID, apiv1.DiskMeta) (apiv1.SnapshotCID, error)
@@ -783,7 +783,7 @@ func (fake *FakeCPI) ResizeDiskReturns(result1 error) {
 	}{result1}
 }
 
-func (fake *FakeCPI) UpdateDisk(arg1 apiv1.DiskCID, arg2 int, arg3 apiv1.DiskCloudProps) (*apiv1.DiskCID, error) {
+func (fake *FakeCPI) UpdateDisk(arg1 apiv1.DiskCID, arg2 int, arg3 apiv1.DiskCloudProps) (apiv1.DiskCID, error) {
 	fake.updateDiskMutex.Lock()
 	fake.updateDiskArgsForCall = append(fake.updateDiskArgsForCall, struct {
 		arg1 apiv1.DiskCID
@@ -810,10 +810,10 @@ func (fake *FakeCPI) UpdateDiskArgsForCall(i int) (apiv1.DiskCID, int, apiv1.Dis
 	return fake.updateDiskArgsForCall[i].arg1, fake.updateDiskArgsForCall[i].arg2, fake.updateDiskArgsForCall[i].arg3
 }
 
-func (fake *FakeCPI) UpdateDiskReturns(result1 *apiv1.DiskCID, result2 error) {
+func (fake *FakeCPI) UpdateDiskReturns(result1 apiv1.DiskCID, result2 error) {
 	fake.UpdateDiskStub = nil
 	fake.updateDiskReturns = struct {
-		result1 *apiv1.DiskCID
+		result1 apiv1.DiskCID
 		result2 error
 	}{result1, result2}
 }

--- a/apiv1/interfaces_disks.go
+++ b/apiv1/interfaces_disks.go
@@ -17,9 +17,11 @@ type DisksV2Additions interface {
 }
 
 // DiskUpdater is an opt-in CPI capability corresponding to the BOSH CPI v2
-// `update_disk` method.
+// `update_disk` method. The returned *DiskCID is nil when the disk was
+// updated in place (the Director keeps using the original CID), or a new
+// disk's CID when the CPI replaced the disk (e.g. snapshot + recreate).
 type DiskUpdater interface {
-	UpdateDisk(DiskCID, int, DiskCloudProps) (interface{}, error)
+	UpdateDisk(DiskCID, int, DiskCloudProps) (*DiskCID, error)
 }
 
 type DiskCloudProps interface {

--- a/apiv1/interfaces_disks.go
+++ b/apiv1/interfaces_disks.go
@@ -10,6 +10,7 @@ type DisksV1 interface {
 
 	HasDisk(DiskCID) (bool, error)
 	ResizeDisk(DiskCID, int) error
+	UpdateDisk(DiskCID, int, DiskCloudProps) (interface{}, error)
 }
 
 type DisksV2Additions interface {

--- a/apiv1/interfaces_disks.go
+++ b/apiv1/interfaces_disks.go
@@ -10,11 +10,11 @@ type DisksV1 interface {
 
 	HasDisk(DiskCID) (bool, error)
 	ResizeDisk(DiskCID, int) error
-	UpdateDisk(DiskCID, int, DiskCloudProps) (interface{}, error)
 }
 
 type DisksV2Additions interface {
 	AttachDiskV2(VMCID, DiskCID) (DiskHint, error)
+	UpdateDisk(DiskCID, int, DiskCloudProps) (interface{}, error)
 }
 
 type DiskCloudProps interface {

--- a/apiv1/interfaces_disks.go
+++ b/apiv1/interfaces_disks.go
@@ -14,6 +14,11 @@ type DisksV1 interface {
 
 type DisksV2Additions interface {
 	AttachDiskV2(VMCID, DiskCID) (DiskHint, error)
+}
+
+// DiskUpdater is an opt-in CPI capability corresponding to the BOSH CPI v2
+// `update_disk` method.
+type DiskUpdater interface {
 	UpdateDisk(DiskCID, int, DiskCloudProps) (interface{}, error)
 }
 

--- a/apiv1/interfaces_disks.go
+++ b/apiv1/interfaces_disks.go
@@ -16,12 +16,11 @@ type DisksV2Additions interface {
 	AttachDiskV2(VMCID, DiskCID) (DiskHint, error)
 }
 
-// DiskUpdater is an opt-in CPI capability corresponding to the BOSH CPI v2
-// `update_disk` method. The returned *DiskCID is nil when the disk was
-// updated in place (the Director keeps using the original CID), or a new
-// disk's CID when the CPI replaced the disk (e.g. snapshot + recreate).
+// DiskUpdater is an opt-in CPI capability for the BOSH CPI v2 `update_disk`
+// method. It returns the CID the Director should use going forward: the
+// original CID for in-place updates, or a new CID if the disk was replaced.
 type DiskUpdater interface {
-	UpdateDisk(DiskCID, int, DiskCloudProps) (*DiskCID, error)
+	UpdateDisk(DiskCID, int, DiskCloudProps) (DiskCID, error)
 }
 
 type DiskCloudProps interface {

--- a/docs/example.go
+++ b/docs/example.go
@@ -120,8 +120,8 @@ func (c CPI) ResizeDisk(cid apiv1.DiskCID, size int) error {
 	return nil
 }
 
-func (c CPI) UpdateDisk(cid apiv1.DiskCID, size int, props apiv1.DiskCloudProps) (interface{}, error) {
-	return cid.AsString(), nil
+func (c CPI) UpdateDisk(cid apiv1.DiskCID, size int, props apiv1.DiskCloudProps) (*apiv1.DiskCID, error) {
+	return nil, nil
 }
 
 func (c CPI) SnapshotDisk(cid apiv1.DiskCID, meta apiv1.DiskMeta) (apiv1.SnapshotCID, error) {

--- a/docs/example.go
+++ b/docs/example.go
@@ -120,6 +120,10 @@ func (c CPI) ResizeDisk(cid apiv1.DiskCID, size int) error {
 	return nil
 }
 
+func (c CPI) UpdateDisk(cid apiv1.DiskCID, size int, props apiv1.DiskCloudProps) (interface{}, error) {
+	return cid.AsString(), nil
+}
+
 func (c CPI) SnapshotDisk(cid apiv1.DiskCID, meta apiv1.DiskMeta) (apiv1.SnapshotCID, error) {
 	return apiv1.NewSnapshotCID("snap-cid"), nil
 }

--- a/docs/example.go
+++ b/docs/example.go
@@ -120,8 +120,8 @@ func (c CPI) ResizeDisk(cid apiv1.DiskCID, size int) error {
 	return nil
 }
 
-func (c CPI) UpdateDisk(cid apiv1.DiskCID, size int, props apiv1.DiskCloudProps) (*apiv1.DiskCID, error) {
-	return nil, nil
+func (c CPI) UpdateDisk(cid apiv1.DiskCID, size int, props apiv1.DiskCloudProps) (apiv1.DiskCID, error) {
+	return cid, nil
 }
 
 func (c CPI) SnapshotDisk(cid apiv1.DiskCID, meta apiv1.DiskMeta) (apiv1.SnapshotCID, error) {

--- a/rpc/factory_test.go
+++ b/rpc/factory_test.go
@@ -539,11 +539,11 @@ var _ = Describe("Factory", func() {
 	})
 
 	Describe("update_disk", func() {
-		It("works when CPI implements DiskUpdater", func() {
-			cpi.UpdateDiskReturns("disk-cid", nil)
+		It("works with in-place update (nil new CID)", func() {
+			cpi.UpdateDiskReturns(nil, nil)
 
 			resp, _ := act(`{"method":"update_disk", "arguments":["disk-cid", 1000, {"cp1": "cp1-val"}], "api_version": 2}`)
-			Expect(resp).To(Equal(Response{Result: "disk-cid"}))
+			Expect(resp).To(Equal(Response{Result: nil}))
 
 			diskCID, size, cloudProps := cpi.UpdateDiskArgsForCall(0)
 			Expect(diskCID).To(Equal(apiv1.NewDiskCID("disk-cid")))
@@ -552,6 +552,14 @@ var _ = Describe("Factory", func() {
 			var cp FakeCPs
 			Expect(cloudProps.As(&cp)).ToNot(HaveOccurred())
 			Expect(cp).To(Equal(FakeCPs{CP: "cp1-val"}))
+		})
+
+		It("works with disk replacement (new CID returned)", func() {
+			newCID := apiv1.NewDiskCID("new-disk-cid")
+			cpi.UpdateDiskReturns(&newCID, nil)
+
+			resp, _ := act(`{"method":"update_disk", "arguments":["disk-cid", 1000, {}], "api_version": 2}`)
+			Expect(resp).To(Equal(Response{Result: "new-disk-cid"}))
 		})
 
 		It("errs when CPI's UpdateDisk returns an error", func() {

--- a/rpc/factory_test.go
+++ b/rpc/factory_test.go
@@ -538,6 +538,38 @@ var _ = Describe("Factory", func() {
 		})
 	})
 
+	Describe("update_disk", func() {
+		It("works when CPI implements DiskUpdater", func() {
+			cpi.UpdateDiskReturns("disk-cid", nil)
+
+			resp, _ := act(`{"method":"update_disk", "arguments":["disk-cid", 1000, {"cp1": "cp1-val"}], "api_version": 2}`)
+			Expect(resp).To(Equal(Response{Result: "disk-cid"}))
+
+			diskCID, size, cloudProps := cpi.UpdateDiskArgsForCall(0)
+			Expect(diskCID).To(Equal(apiv1.NewDiskCID("disk-cid")))
+			Expect(size).To(Equal(1000))
+
+			var cp FakeCPs
+			Expect(cloudProps.As(&cp)).ToNot(HaveOccurred())
+			Expect(cp).To(Equal(FakeCPs{CP: "cp1-val"}))
+		})
+
+		It("errs when CPI's UpdateDisk returns an error", func() {
+			cpi.UpdateDiskReturns(nil, errors.New("err"))
+
+			resp, _ := act(`{"method":"update_disk", "arguments":["disk-cid", 1000, {}], "api_version": 2}`)
+			Expect(resp).To(Equal(Response{Error: &ResponseError{Type: "Bosh::Clouds::CloudError", Message: "err"}}))
+		})
+
+		It("rejects api_version < 2", func() {
+			resp, _ := act(`{"method":"update_disk", "arguments":["disk-cid", 1000, {}]}`)
+			Expect(resp.Error).ToNot(BeNil())
+			Expect(resp.Error.Message).To(ContainSubstring("requires CPI API version 2 or higher"))
+			Expect(cpi.UpdateDiskCallCount()).To(Equal(0))
+		})
+
+	})
+
 	Describe("snapshot_disk", func() {
 		It("works", func() {
 			cpi.SnapshotDiskReturns(apiv1.NewSnapshotCID("snap-cid"), nil)

--- a/rpc/factory_test.go
+++ b/rpc/factory_test.go
@@ -539,11 +539,11 @@ var _ = Describe("Factory", func() {
 	})
 
 	Describe("update_disk", func() {
-		It("works with in-place update (nil new CID)", func() {
-			cpi.UpdateDiskReturns(nil, nil)
+		It("works with in-place update (original CID returned)", func() {
+			cpi.UpdateDiskReturns(apiv1.NewDiskCID("disk-cid"), nil)
 
 			resp, _ := act(`{"method":"update_disk", "arguments":["disk-cid", 1000, {"cp1": "cp1-val"}], "api_version": 2}`)
-			Expect(resp).To(Equal(Response{Result: nil}))
+			Expect(resp).To(Equal(Response{Result: "disk-cid"}))
 
 			diskCID, size, cloudProps := cpi.UpdateDiskArgsForCall(0)
 			Expect(diskCID).To(Equal(apiv1.NewDiskCID("disk-cid")))
@@ -555,15 +555,14 @@ var _ = Describe("Factory", func() {
 		})
 
 		It("works with disk replacement (new CID returned)", func() {
-			newCID := apiv1.NewDiskCID("new-disk-cid")
-			cpi.UpdateDiskReturns(&newCID, nil)
+			cpi.UpdateDiskReturns(apiv1.NewDiskCID("new-disk-cid"), nil)
 
 			resp, _ := act(`{"method":"update_disk", "arguments":["disk-cid", 1000, {}], "api_version": 2}`)
 			Expect(resp).To(Equal(Response{Result: "new-disk-cid"}))
 		})
 
 		It("errs when CPI's UpdateDisk returns an error", func() {
-			cpi.UpdateDiskReturns(nil, errors.New("err"))
+			cpi.UpdateDiskReturns(apiv1.DiskCID{}, errors.New("err"))
 
 			resp, _ := act(`{"method":"update_disk", "arguments":["disk-cid", 1000, {}], "api_version": 2}`)
 			Expect(resp).To(Equal(Response{Error: &ResponseError{Type: "Bosh::Clouds::CloudError", Message: "err"}}))

--- a/rpc/factory_test.go
+++ b/rpc/factory_test.go
@@ -575,6 +575,14 @@ var _ = Describe("Factory", func() {
 			Expect(cpi.UpdateDiskCallCount()).To(Equal(0))
 		})
 
+		It("returns NotSupported when CPI does not implement DiskUpdater", func() {
+			type noUpdateDiskCPI struct{ apiv1.CPI }
+			cpiFactory.NewStub = func(_ apiv1.CallContext) (apiv1.CPI, error) { return noUpdateDiskCPI{cpi}, nil }
+			resp, _ := act(`{"method":"update_disk", "arguments":["disk-cid", 1000, {}], "api_version": 2}`)
+			Expect(resp).To(Equal(Response{Error: &ResponseError{Type: "Bosh::Clouds::NotSupported", Message: "Method 'update_disk' is not supported by this CPI"}}))
+			Expect(cpi.UpdateDiskCallCount()).To(Equal(0))
+		})
+
 	})
 
 	Describe("snapshot_disk", func() {


### PR DESCRIPTION
## Summary

Adds `update_disk` to the CPI v2 API so Go-based CPIs built on this library can receive `update_disk` calls from the BOSH director.

`update_disk` is part of the [BOSH CPI API v2](https://bosh.io/docs/cpi-api-v2-method/update-disk/) but the framework didn't expose it — `ActionFactory` returned `Unknown method 'update_disk'`.

## Changes

| File | Change |
|------|--------|
| `apiv1/interfaces_disks.go` | Adds a new standalone opt-in `DiskUpdater` interface: `UpdateDisk(DiskCID, int, DiskCloudProps) (DiskCID, error)`. Returns the CID the Director should use going forward — the original CID for in-place updates, or a new CID if the disk was replaced. |
| `apiv1/action_factory.go` | Adds the `update_disk` dispatch case, gated on `apiVersion >= 2`. When the CPI does not implement `DiskUpdater`, dispatch returns an action yielding a typed `Bosh::Clouds::NotSupported` cloud error (not `NotImplemented`), so the Director can fall back cleanly. |
| `apiv1/apiv1fakes/fake_cpi.go` | Counterfeiter-style fake for `UpdateDisk` (the fake also satisfies `DiskUpdater`, so it exercises the opt-in path). |
| `docs/example.go` | Stub `UpdateDisk` implementation demonstrating a CPI that opts into `DiskUpdater`. |
| `rpc/factory_test.go` | Tests for the happy paths (in-place / disk-replacement / error), `api_version < 2` gating, and the opt-out path asserting a `Bosh::Clouds::NotSupported` response when the CPI does not implement `DiskUpdater`. |

## Error semantics

`update_disk` is optional in the CPI v2 spec — the Director falls back to its own snapshot / detach / create-new-disk / attach migration when the CPI doesn't support it. For that fallback to trigger, the CPI must respond with `Bosh::Clouds::NotSupported`, **not** `Bosh::Clouds::NotImplemented` (which signals the method doesn't exist at all and fails the deploy).

Because errors returned from `ActionFactory.Create` are surfaced by `JSONDispatcher` as `Bosh::Clouds::NotImplemented`, the opt-out case instead returns a valid action that yields a typed error whose `Type()` is `Bosh::Clouds::NotSupported`. `JSONDispatcher.cloudError` reads that type for the wire response. This frees downstream CPIs from having to hand-write `Bosh::Clouds::NotSupported` stubs.

## Compatibility

Modeled as a separate opt-in interface rather than added to `DisksV2Additions`, so CPIs that don't implement `update_disk` compile unchanged when they re-vendor.

Empirically verified against all downstream Go CPIs that vendor `bosh-cpi-go`:

| CPI | Result |
|-----|--------|
| `bosh-alicloud-cpi-release` | ✓ builds unchanged against this PR |
| `bosh-docker-cpi-release` | ✓ builds unchanged against this PR |
| `bosh-openstack-cpi-release` (golang) | ✓ builds unchanged against this PR |
| `bosh-virtualbox-cpi-release` | ✓ builds unchanged against this PR |
| `bosh-warden-cpi-release` | ✓ builds unchanged against this PR |
| `bosh-google-cpi-release` | N/A — does not vendor `bosh-cpi-go` |

Method: shallow-cloned each CPI, replaced its vendored `apiv1/interfaces_disks.go` and `apiv1/action_factory.go` with the versions from this PR, ran `go build ./...` in each Go module. All build clean.

For contrast, placing `UpdateDisk` on `DisksV2Additions` (the shape the PR previously used) fails to compile in all five above — each CPI has a `type CPI struct{}` returned by `Factory.New(...) (apiv1.CPI, error)`, and since `apiv1.CPI` transitively composes `DisksV2Additions`, adding a required method there forces an `UpdateDisk` stub in every downstream CPI at re-vendor time.
